### PR TITLE
Fix libxml2 missing headers

### DIFF
--- a/recipes-asterisk/asterisk/asterisk_13.13.1.bb
+++ b/recipes-asterisk/asterisk/asterisk_13.13.1.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "http://www.asterisk.org/"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3aa955c628d43053f8ba9569d173105a"
 
-DEPENDS += "jansson sqlite3 libedit alsa-lib util-linux"
+DEPENDS += "jansson sqlite3 libedit alsa-lib util-linux libxml2"
 RDEPENDS_${PN} += "bash"
 
 SRC_URI = "\


### PR DESCRIPTION
Asterisk fails to compile in my Pyro Yocto environment due tu missing libxml2 header file. Following patch fixes the issue.


```
Error log:
...
gcc -isystem/home/YoctoBSP/build-hboxv2/tmp/work/armv7at2hf-neon-hg-linux-gnueabi/asterisk/13.13.1-r0/recipe-sysroot-native/usr/include -O2 -pipe -g -D_GNU_SOURCE -Wall    -c -o menuselect.o menuselect.c
menuselect.c:35:27: fatal error: libxml/parser.h: No such file or directory
compilation terminated.
<builtin>: recipe for target 'menuselect.o' failed
make[1]: *** [menuselect.o] Error 1
make[1]: Leaving directory '/home/hager/YoctoBSP/build-hboxv2/tmp/work/armv7at2hf-neon-hg-linux-gnueabi/asterisk/13.13.1-r0/asterisk-13.13.1/menuselect'
Makefile:975: recipe for target 'menuselect/menuselect' failed
make: *** [menuselect/menuselect] Error 2
WARNING: exit code 2 from a shell command.
ERROR: Function failed: do_configure
...
```